### PR TITLE
Implement NodeScopeResolverTestPHPVersionMutator

### DIFF
--- a/resources/infection.json5
+++ b/resources/infection.json5
@@ -15,7 +15,8 @@
     "PHPStan\\Infection\\IsSuperTypeOfCalleeAndArgumentMutator": true,
     "PHPStan\\Infection\\LooseBooleanMutator": true,
     "PHPStan\\Infection\\TrinaryLogicMutator": true,
-    "PHPStan\\Infection\\TrueTruthyFalseFalseyTypeSpecifierContextMutator": true
+    "PHPStan\\Infection\\TrueTruthyFalseFalseyTypeSpecifierContextMutator": true,
+    "PHPStan\\Infection\\NodeScopeResolverTestPHPVersionMutator": true
   },
   "bootstrap": "build-infection/vendor/autoload.php"
 }

--- a/src/Infection/NodeScopeResolverTestPHPVersionMutator.php
+++ b/src/Infection/NodeScopeResolverTestPHPVersionMutator.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Infection;
+
+use Infection\Mutator\Definition;
+use Infection\Mutator\Mutator;
+use Infection\Mutator\MutatorCategory;
+use Infection\PhpParser\Visitor\ParentConnector;
+use LogicException;
+use PhpParser\Node;
+use function in_array;
+
+/**
+ * @implements Mutator<Node\Expr\MethodCall|Node\Expr\BooleanNot>
+ */
+final class NodeScopeResolverTestPHPVersionMutator implements Mutator
+{
+
+	public static function getDefinition(): Definition
+	{
+		return new Definition(
+			<<<'TXT'
+				Replaces "// lint >= 8.0" conditions in test-files with previous versions.
+				TXT
+			,
+			MutatorCategory::ORTHOGONAL_REPLACEMENT,
+			null,
+			<<<'DIFF'
+				- // lint >= 8.0
+				+ // lint >= 7.4
+			DIFF,
+		);
+	}
+
+	public function getName(): string
+	{
+		return self::class;
+	}
+
+	public function canMutate(Node $node): bool
+	{
+		if ($node instanceof Node\Stmt\Nop) {
+			$x=1;
+		}
+
+		return true;
+	}
+
+	public function mutate(Node $node): iterable
+	{
+		if ($node instanceof Node\Expr\BooleanNot) {
+			$node = $node->expr;
+			if (!$node instanceof Node\Expr\MethodCall) {
+				throw new LogicException();
+			}
+
+			if (!$node->name instanceof Node\Identifier) {
+				throw new LogicException();
+			}
+
+			if ($node->name->name === 'yes') {
+				yield new Node\Expr\MethodCall($node->var, 'no');
+			} else {
+				yield new Node\Expr\MethodCall($node->var, 'yes');
+			}
+
+			return;
+		}
+
+		if (!$node->name instanceof Node\Identifier) {
+			throw new LogicException();
+		}
+
+		if ($node->name->name === 'yes') {
+			yield new Node\Expr\BooleanNot(new Node\Expr\MethodCall($node->var, 'no'));
+		} else {
+			yield new Node\Expr\BooleanNot(new Node\Expr\MethodCall($node->var, 'yes'));
+		}
+	}
+
+}

--- a/tests/Infection/NodeScopeResolverTestPHPVersionMutatorTest.php
+++ b/tests/Infection/NodeScopeResolverTestPHPVersionMutatorTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Infection;
+
+use Infection\Testing\BaseMutatorTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(NodeScopeResolverTestPHPVersionMutator::class)]
+final class NodeScopeResolverTestPHPVersionMutatorTest extends BaseMutatorTestCase
+{
+
+	/**
+	 * @param string|string[] $expected
+	 */
+	#[DataProvider('mutationsProvider')]
+	public function testMutator(string $input, $expected = []): void
+	{
+		$this->assertMutatesInput($input, $expected);
+	}
+
+	/**
+	 * @return iterable<string, array{0: string, 1?: string}>
+	 */
+	public static function mutationsProvider(): iterable
+	{
+		yield 'It mutates lint-comment to php7' => [
+			<<<'PHP'
+				<?php // lint >= 8.0
+
+				$x = 1;
+				PHP
+,
+			<<<'PHP'
+				<?php // lint >= 7.4
+
+				$x = 1;
+				PHP
+,
+		];
+		/*
+
+		yield 'It mutates lint-comment to previous minor version' => [
+			<<<'PHP'
+				<?php // lint >= 8.4
+
+				$x = 1;
+				PHP
+,
+			<<<'PHP'
+				<?php // lint >= 8.3
+
+				$x = 1;
+				PHP
+,
+		];
+
+		yield 'No mutations when no lint comment' => [
+			<<<'PHP'
+				<?php declare(strict_types = 1);
+
+				$x = 1;
+				PHP
+			,
+		];
+		*/
+	}
+
+	protected function getTestedMutatorClassName(): string
+	{
+		return NodeScopeResolverTestPHPVersionMutator::class;
+	}
+
+}


### PR DESCRIPTION
In PHPStan-src we use test-files which start with a comment, indicating the min-php version required to run the test like `<?php // lint >= 7.4`.

we want this version to be the lowest possible, which is necessary to run the test (to maximize php version coverage).
since this version is provided by contributors it might not fit this constraint.

now I came up with the idea to let infection mutate `<?php // lint >= 8.0` into `<?php // lint >= 7.4`, so we can see whether the test contains the lowest minimum version possible.