### PR TITLE
fix(tests): Fix the mutator tests

### DIFF
--- a/tests/Infection/IsSuperTypeOfCalleeAndArgumentMutatorTest.php
+++ b/tests/Infection/IsSuperTypeOfCalleeAndArgumentMutatorTest.php
@@ -2,12 +2,11 @@
 
 namespace PHPStan\Infection;
 
-use Infection\Testing\BaseMutatorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(IsSuperTypeOfCalleeAndArgumentMutator::class)]
-final class IsSuperTypeOfCalleeAndArgumentMutatorTest extends BaseMutatorTestCase
+final class IsSuperTypeOfCalleeAndArgumentMutatorTest extends MutatorTestCase
 {
 
 	/**
@@ -16,7 +15,7 @@ final class IsSuperTypeOfCalleeAndArgumentMutatorTest extends BaseMutatorTestCas
 	#[DataProvider('mutationsProvider')]
 	public function testMutator(string $input, $expected = []): void
 	{
-		$this->assertMutatesInput($input, $expected);
+		$this->assertMutatesMethodInput($input, $expected);
 	}
 
 	/**

--- a/tests/Infection/LooseBooleanMutatorTest.php
+++ b/tests/Infection/LooseBooleanMutatorTest.php
@@ -2,12 +2,11 @@
 
 namespace PHPStan\Infection;
 
-use Infection\Testing\BaseMutatorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(LooseBooleanMutator::class)]
-final class LooseBooleanMutatorTest extends BaseMutatorTestCase
+final class LooseBooleanMutatorTest extends MutatorTestCase
 {
 
 	/**
@@ -16,7 +15,7 @@ final class LooseBooleanMutatorTest extends BaseMutatorTestCase
 	#[DataProvider('mutationsProvider')]
 	public function testMutator(string $input, $expected = []): void
 	{
-		$this->assertMutatesInput($input, $expected);
+		$this->assertMutatesMethodInput($input, $expected);
 	}
 
 	/**

--- a/tests/Infection/MutatorTestCase.php
+++ b/tests/Infection/MutatorTestCase.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Infection;
+
+use Infection\Testing\BaseMutatorTestCase;
+use function array_map;
+use function method_exists;
+use function preg_replace;
+use function sprintf;
+use function str_starts_with;
+use function substr;
+
+abstract class MutatorTestCase extends BaseMutatorTestCase
+{
+
+	/**
+	 * @param string|string[] $expected
+	 */
+	final protected function assertMutatesMethodInput(string $input, string|array $expected = []): void
+	{
+		$this->assertMutatesInput(
+			$this->wrapInMethod($input),
+			array_map(
+                $this->wrapInMethod(...),
+                (array) $expected,
+            ),
+		);
+	}
+
+	private function wrapInMethod(string $code): string
+	{
+		$code = $this->stripOpeningTag($code);
+
+		if (method_exists(BaseMutatorTestCase::class, 'wrapCodeInMethod')) {
+			return BaseMutatorTestCase::wrapCodeInMethod($code);
+		}
+
+		$indentedCode = preg_replace('/^/m', '        ', $code);
+
+		return sprintf(
+			<<<'PHP'
+				<?php
+
+				class WrappingClass {
+				    public function wrappedTestedCode() {
+				%s
+				    }
+				}
+				PHP,
+			$indentedCode,
+		);
+	}
+
+	private function stripOpeningTag(string $code): string
+	{
+        return str_starts_with($code, '<?php')
+            ? (preg_replace('/^\s*\R?/', '', substr($code, 5)) ?? '')
+            : $code;
+	}
+
+}

--- a/tests/Infection/MutatorTestCase.php
+++ b/tests/Infection/MutatorTestCase.php
@@ -21,9 +21,9 @@ abstract class MutatorTestCase extends BaseMutatorTestCase
 		$this->assertMutatesInput(
 			$this->wrapInMethod($input),
 			array_map(
-                $this->wrapInMethod(...),
-                (array) $expected,
-            ),
+				$this->wrapInMethod(...),
+				(array) $expected,
+			),
 		);
 	}
 
@@ -53,9 +53,9 @@ abstract class MutatorTestCase extends BaseMutatorTestCase
 
 	private function stripOpeningTag(string $code): string
 	{
-        return str_starts_with($code, '<?php')
-            ? (preg_replace('/^\s*\R?/', '', substr($code, 5)) ?? '')
-            : $code;
+		return str_starts_with($code, '<?php')
+			? (preg_replace('/^\s*\R?/', '', substr($code, 5)) ?? '')
+			: $code;
 	}
 
 }

--- a/tests/Infection/NonFalseyNonEmptyStringMutatorTest.php
+++ b/tests/Infection/NonFalseyNonEmptyStringMutatorTest.php
@@ -2,12 +2,11 @@
 
 namespace PHPStan\Infection;
 
-use Infection\Testing\BaseMutatorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(NonFalseyNonEmptyStringMutator::class)]
-final class NonFalseyNonEmptyStringMutatorTest extends BaseMutatorTestCase
+final class NonFalseyNonEmptyStringMutatorTest extends MutatorTestCase
 {
 
 	/**
@@ -16,7 +15,7 @@ final class NonFalseyNonEmptyStringMutatorTest extends BaseMutatorTestCase
 	#[DataProvider('mutationsProvider')]
 	public function testMutator(string $input, $expected = []): void
 	{
-		$this->assertMutatesInput($input, $expected);
+		$this->assertMutatesMethodInput($input, $expected);
 	}
 
 	/**

--- a/tests/Infection/TrinaryLogicMutatorTest.php
+++ b/tests/Infection/TrinaryLogicMutatorTest.php
@@ -2,12 +2,11 @@
 
 namespace PHPStan\Infection;
 
-use Infection\Testing\BaseMutatorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(TrinaryLogicMutator::class)]
-final class TrinaryLogicMutatorTest extends BaseMutatorTestCase
+final class TrinaryLogicMutatorTest extends MutatorTestCase
 {
 
 	/**
@@ -16,7 +15,7 @@ final class TrinaryLogicMutatorTest extends BaseMutatorTestCase
 	#[DataProvider('mutationsProvider')]
 	public function testMutator(string $input, $expected = []): void
 	{
-		$this->assertMutatesInput($input, $expected);
+		$this->assertMutatesMethodInput($input, $expected);
 	}
 
 	/**

--- a/tests/Infection/TrueTruthyFalseFalseyTypeSpecifierContextMutatorTest.php
+++ b/tests/Infection/TrueTruthyFalseFalseyTypeSpecifierContextMutatorTest.php
@@ -2,12 +2,11 @@
 
 namespace PHPStan\Infection;
 
-use Infection\Testing\BaseMutatorTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(TrueTruthyFalseFalseyTypeSpecifierContextMutator::class)]
-final class TrueTruthyFalseFalseyTypeSpecifierContextMutatorTest extends BaseMutatorTestCase
+final class TrueTruthyFalseFalseyTypeSpecifierContextMutatorTest extends MutatorTestCase
 {
 
 	/**
@@ -16,7 +15,7 @@ final class TrueTruthyFalseFalseyTypeSpecifierContextMutatorTest extends BaseMut
 	#[DataProvider('mutationsProvider')]
 	public function testMutator(string $input, $expected = []): void
 	{
-		$this->assertMutatesInput($input, $expected);
+		$this->assertMutatesMethodInput($input, $expected);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

In https://github.com/infection/infection/issues/3120, Infection's base mutator test case changed to better mimic how infection actually parses and processes the PHP code. One of the consequences, is that code that belongs to non-method is no longer mutated, as those are ineligible nodes from infection perspective.

## Related issues

This PR is a follow up of https://github.com/infection/infection/pull/3219. It was discussed more extensively in https://github.com/infection/infection/pull/2832 and the impact on PHPStan was actually taken into consideration. So here is the change necessary.